### PR TITLE
Adjust event category probability split to 45/35/20

### DIFF
--- a/src/utilities/setPlayerEvent.opy
+++ b/src/utilities/setPlayerEvent.opy
@@ -16,7 +16,7 @@ def setPlayerEvent():
             eventPlayer.eventForceRoll = null
     else:
         eventPlayer.categoryRoll = random.randint(0, 100)
-    if eventPlayer.categoryRoll <= 40:
+    if eventPlayer.categoryRoll <= 45:
         eventPlayer.eventType = 0
         rejecSampling()
         eventPlayer.eventName = buffEvent[eventPlayer.eventId][0]
@@ -67,5 +67,4 @@ def setPlayerEvent():
     lbl_2:
     setEventDuration()
     lbl_1:
-
 


### PR DESCRIPTION
### Motivation
- 将事件类别概率从 40/40/20 调整为 45/35/20（增益/减益/机制），以匹配新的设计权重。

### Description
- 在 `src/utilities/setPlayerEvent.opy` 中将 `if eventPlayer.categoryRoll <= 40:` 修改为 `if eventPlayer.categoryRoll <= 45:`，保留 `elif eventPlayer.categoryRoll <= 80:` 不变，`main.opy`/`devMain.opy` 未做改动且共享此工具逻辑。

### Testing
- 运行了 `rg -n "categoryRoll|random.randint(0, 100)|<= 45|<= 80" src/utilities/setPlayerEvent.opy`、查看了 `git diff`、提交变更（`git commit`），并通过 `make_pr` 创建了 PR，所有自动化检查均通过且工作区为干净状态。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee785086c8328ad3bcd51c6e4cf40)