### PR TITLE
fix: 修复死亡延迟在死亡后才触发的问题

### DIFF
--- a/docs/modules/03-events-system.md
+++ b/docs/modules/03-events-system.md
@@ -68,6 +68,7 @@
 ## 性能与稳定性点
 
 - 大量 `eachPlayer` 规则中采用 `wait(...)`、`waitUntil(...)`、短路条件。
+- 「死亡延迟（Buff 11）」在致命伤害帧立即施加 `UNKILLABLE`，并增加“未处于 UNKILLABLE”前置条件，避免多段伤害（如堡垒榴弹）导致效果在死亡后才误触发。
 - 清理逻辑统一走 `clearPlayerEvent()`，减少状态泄漏。
 - 数值更新统一走 `updatePlayerStats()`，避免重复写 setXxx。
 

--- a/src/events/effects/buffEffects.opy
+++ b/src/events/effects/buffEffects.opy
@@ -214,9 +214,9 @@ rule "[VishkarEvent]: 死亡延迟":
     @Event playerTookDamage
     @Team 1
     @Condition all([dlcVishkarEvent, eventPlayer.hasSpawned(), eventPlayer.eventType == 0, eventPlayer.eventId == 11, attacker.getHero() != eventPlayer.getHero()]) == true
+    @Condition eventPlayer.hasStatus(Status.UNKILLABLE) != true
     @Condition (any([eventDamage >= eventPlayer.getHealth(), eventPlayer.getHealth() <= eventPlayer.getMaxHealth() * EVT_11_TRIGGER_HP_PERCENT, eventAbility == Button.SECONDARY_FIRE and attacker.getHero() == Hero.BASTION and eventPlayer.getMaxHealth() <= EVT_11_BASTION_EXECUTE_HP])) == true
-    
-    wait(0.016)
+
     eventPlayer.setStatusEffect(eventPlayer, Status.UNKILLABLE, eventPlayer.eventDuration)
     createEffect(getAllPlayers(), Effect.BAPTISTE_IMMORTALITY_FIELD_PROTECTED, Color.TEAM_1, eventPlayer, 200, EffectReeval.POSITION_AND_RADIUS)
     eventPlayer.invincibleEffect = getLastCreatedEntity()


### PR DESCRIPTION
### Motivation
- Fix a timing bug where the "death delay" event (Buff 11) could be applied after the player had already died and respawned due to multi-stage damage (e.g. Bastion grenade direct + splash), causing the delayed-execute effect to occur on the revived player instead of the original lethal frame.

### Description
- Remove the delayed `wait(0.016)` and apply `UNKILLABLE` immediately when the lethal condition is detected, and add a guard `eventPlayer.hasStatus(Status.UNKILLABLE) != true` to prevent duplicate triggers in the same window; the implementation change is in `src/events/effects/buffEffects.opy` and the event-system note was added to `docs/modules/03-events-system.md`.

### Testing
- Performed repository-wide static searches for related symbols and inspected `src/events/effects/buffEffects.opy` to confirm `wait(0.016)` was removed and the `UNKILLABLE` precondition was added, and verified the documentation update in `docs/modules/03-events-system.md`, and these automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ffd60f34c8328a60caa170f87f6fe)