### PR TITLE
Fix end/portal progression checks while in possession state

### DIFF
--- a/src/devMain.opy
+++ b/src/devMain.opy
@@ -531,7 +531,7 @@ rule "when a player reaches the control jump point, they move on to the next map
     
     wait(0.032, Wait.ABORT_WHEN_FALSE)
     wait(0.2)
-    if all([eventPlayer.getPosition().y >= controlJumpPosition[eventPlayer.controlJumpIndex].y, distance(eventPlayer.getPosition() * vect(1, 0, 1), controlJumpPosition[eventPlayer.controlJumpIndex] * vect(1, 0, 1)) <= 4]):
+    if all([((eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()).y >= controlJumpPosition[eventPlayer.controlJumpIndex].y), distance((eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()) * vect(1, 0, 1), controlJumpPosition[eventPlayer.controlJumpIndex] * vect(1, 0, 1)) <= 4]):
         if controlJumpPosition[eventPlayer.controlJumpIndex] == null:
             goto lbl_0
         eventPlayer.controlJumpIndex++
@@ -551,8 +551,8 @@ rule "when a player reaches the end, they move on to the next hero or win if the
     @Event eachPlayer
     @Team 1
     @Condition eventPlayer.hasSpawned() == true
-    @Condition eventPlayer.getPosition().y >= endPosition.y
-    @Condition distance(eventPlayer.getPosition() * vect(1, 0, 1), endPosition * vect(1, 0, 1)) <= 4
+    @Condition (eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()).y >= endPosition.y
+    @Condition distance((eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()) * vect(1, 0, 1), endPosition * vect(1, 0, 1)) <= 4
     
     eventPlayer.respawn()
     wait(0.032)

--- a/src/main.opy
+++ b/src/main.opy
@@ -545,7 +545,7 @@ rule "when a player reaches the control jump point, they move on to the next map
     
     wait(0.032, Wait.ABORT_WHEN_FALSE)
     wait(0.2)
-    if all([eventPlayer.getPosition().y >= controlJumpPosition[eventPlayer.controlJumpIndex].y, distance(eventPlayer.getPosition() * vect(1, 0, 1), controlJumpPosition[eventPlayer.controlJumpIndex] * vect(1, 0, 1)) <= 4]):
+    if all([((eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()).y >= controlJumpPosition[eventPlayer.controlJumpIndex].y), distance((eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()) * vect(1, 0, 1), controlJumpPosition[eventPlayer.controlJumpIndex] * vect(1, 0, 1)) <= 4]):
         if controlJumpPosition[eventPlayer.controlJumpIndex] == null:
             goto lbl_0
         eventPlayer.controlJumpIndex++
@@ -565,8 +565,8 @@ rule "when a player reaches the end, they move on to the next hero or win if the
     @Event eachPlayer
     @Team 1
     @Condition eventPlayer.hasSpawned() == true
-    @Condition eventPlayer.getPosition().y >= endPosition.y
-    @Condition distance(eventPlayer.getPosition() * vect(1, 0, 1), endPosition * vect(1, 0, 1)) <= 4
+    @Condition (eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()).y >= endPosition.y
+    @Condition distance((eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()) * vect(1, 0, 1), endPosition * vect(1, 0, 1)) <= 4
     
     eventPlayer.respawn()
     wait(0.032)


### PR DESCRIPTION
### Motivation
- Players in the `有我有你` possession state were not triggering control-jump (three-in-one portal) or end-position progression because checks always used `eventPlayer.getPosition()` while the source player is attached to a target.

### Description
- Updated progression detection logic in `src/main.opy` and `src/devMain.opy` to use an effective position that prefers the possessed target's position when `eventPlayer.possess` is active and the target entity exists, otherwise falls back to `eventPlayer.getPosition()`.
- Applied the conditional position expression to both the control-jump check and the end-position checks so attached players correctly progress maps and finish runs.
- Kept changes minimal and aligned between the `main` and `devMain` entry points without altering other gameplay logic.

### Testing
- Ran a repository search to confirm the updated conditional expressions are present in both `src/main.opy` and `src/devMain.opy`, which succeeded.
- Ran `git diff --check` to validate no whitespace/diff issues, which succeeded.
- Ran `git status --short` to confirm only the intended files were modified, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ffe9b8ba88328a7b60acfbd3c8886)