### PR TITLE
fix: clear possessed state when target reaches end

### DIFF
--- a/src/devMain.opy
+++ b/src/devMain.opy
@@ -555,6 +555,8 @@ rule "when a player reaches the end, they move on to the next hero or win if the
     @Condition (eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()).y >= endPosition.y
     @Condition distance((eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()) * vect(1, 0, 1), endPosition * vect(1, 0, 1)) <= 4
     
+    if len(eventPlayer.possessed) > 0:
+        eventPlayer.possessed = []
     eventPlayer.respawn()
     wait(0.032)
     if controlRespawnPosition == null:

--- a/src/main.opy
+++ b/src/main.opy
@@ -569,6 +569,8 @@ rule "when a player reaches the end, they move on to the next hero or win if the
     @Condition (eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()).y >= endPosition.y
     @Condition distance((eventPlayer.possess[0].getPosition() if (eventPlayer.possess != null and eventPlayer.possess[0] != null and entityExists(eventPlayer.possess[0])) else eventPlayer.getPosition()) * vect(1, 0, 1), endPosition * vect(1, 0, 1)) <= 4
     
+    if len(eventPlayer.possessed) > 0:
+        eventPlayer.possessed = []
     eventPlayer.respawn()
     wait(0.032)
     if controlRespawnPosition == null:


### PR DESCRIPTION
### Motivation
- Fix a bug where a player who was being possessed could cross the finish line and break the attachment while their `possessed` receiver state remained set, causing lingering buffs/logic to persist.
- Keep `main` and `devMain` behavior consistent by applying the same minimal change to both entry points per repository conventions.

### Description
- Added a guard in the end-reach rule to clear the receiver state by setting `eventPlayer.possessed = []` when non-empty in `src/main.opy`.
- Applied the identical change to `src/devMain.opy` so production and development entry points remain aligned, with no other behavioral changes.

### Testing
- Verified the inserted lines exist in both files using `rg -n "if len(eventPlayer.possessed) > 0" src/main.opy src/devMain.opy` and confirmed the matches succeeded.
- Inspected the context around the change with `nl -ba src/main.opy | sed -n '564,580p'` and `nl -ba src/devMain.opy | sed -n '552,566p'` to ensure the guard appears before the respawn call.
- Confirmed the repository diff only includes the intended additions with `git diff -- src/main.opy src/devMain.opy` and the diff contained only the expected lines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a11f4fa35c832aa23de54f0ea872f0)