### PR TITLE
fix(phase surge): detect Widowmaker Grapple via Ability1 group

### DIFF
--- a/src/env/game.opy
+++ b/src/env/game.opy
@@ -85,10 +85,10 @@ rule "initialize phase hero arrays":
     @Condition vishkarEventActivated == true
     
     # 技能 1
-    phaseHero[0] = [Hero.DVA, Hero.REINHARDT, Hero.WINSTON, Hero.MAUGA, Hero.HAZARD, Hero.DOOMFIST, Hero.ASHE, Hero.PHARAH, Hero.ECHO, Hero.CASSIDY, Hero.SOLDIER, Hero.REAPER, Hero.SOJOURN, Hero.VENTURE, Hero.GENJI, Hero.TRACER, Hero.MOIRA, Hero.MERCY, Hero.KIRIKO, Hero.ILLARI, Hero.JUNO, Hero.WUYANG, Hero.FREJA, Hero.ANRAN, Hero.JETPACK_CAT, Hero.EMRE, Hero.MIZUKI]
+    phaseHero[0] = [Hero.DVA, Hero.REINHARDT, Hero.WINSTON, Hero.MAUGA, Hero.HAZARD, Hero.DOOMFIST, Hero.ASHE, Hero.PHARAH, Hero.ECHO, Hero.CASSIDY, Hero.SOLDIER, Hero.REAPER, Hero.SOJOURN, Hero.VENTURE, Hero.GENJI, Hero.TRACER, Hero.MOIRA, Hero.MERCY, Hero.KIRIKO, Hero.ILLARI, Hero.JUNO, Hero.WUYANG, Hero.FREJA, Hero.ANRAN, Hero.JETPACK_CAT, Hero.EMRE, Hero.MIZUKI, Hero.WIDOWMAKER]
 
     # 技能 2
-    phaseHero[1] = [Hero.ORISA, Hero.SOMBRA, Hero.TRACER, Hero.FREJA, Hero.REAPER, Hero.WIDOWMAKER]
+    phaseHero[1] = [Hero.ORISA, Hero.SOMBRA, Hero.TRACER, Hero.FREJA, Hero.REAPER]
 
     # 辅助攻击
     phaseHero[2] = [Hero.DOOMFIST, Hero.TRACER, Hero.JETPACK_CAT]


### PR DESCRIPTION
### Motivation
- Fix Phase Surge not triggering for Widowmaker's Grappling Hook because Widowmaker was incorrectly classified under the Ability 2 detection group, causing the wrong input (Venom Mine) to be picked up.

### Description
- Moved `Hero.WIDOWMAKER` from `phaseHero[1]` into `phaseHero[0]` in `src/env/game.opy` so the existing `dashDetector` ability-1 checks will detect Grappling Hook as intended.

### Testing
- Ran `./tools/check_locale_keys.sh` which passed with no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a17a9d3900832ab859eb4ffbdbfc46)