### PR TITLE
Enforce frozen pnpm lockfile in CI and release workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile=false
+        run: pnpm install --frozen-lockfile
 
       - name: Build with OverPy
         run: pnpm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile=false
+        run: pnpm install --frozen-lockfile
 
       - name: Build workshop outputs
         run: pnpm run build:release


### PR DESCRIPTION
### Motivation

- Ensure deterministic, reproducible installs in automated workflows by using the frozen lockfile mode for `pnpm install` instead of the previous `--frozen-lockfile=false` invocation.

### Description

- Updated `pnpm install` invocation in `.github/workflows/ci-build.yml` to use `--frozen-lockfile`.
- Updated `pnpm install` invocation in `.github/workflows/release.yml` to use `--frozen-lockfile`.

### Testing

- Ran the `overpy-build` CI job which executed `pnpm install --frozen-lockfile` and `pnpm run build`, and the job completed successfully.
- Ran the `release` workflow (tag-triggered) which executed `pnpm install --frozen-lockfile` and `pnpm run build:release`, and the workflow completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a18e9fd15c832ab0959391f68bb418)