### PR TITLE
修复“有我有你”解除附身后在三合一地图中未同步 controlJumpIndex 的问题

### DIFF
--- a/docs/modules/03-events-system.md
+++ b/docs/modules/03-events-system.md
@@ -86,6 +86,7 @@
 
 - 大量 `eachPlayer` 规则中采用 `wait(...)`、`waitUntil(...)`、短路条件。
 - 「死亡延迟（Buff 11）」在致命伤害帧立即施加 `UNKILLABLE`，并增加“未处于 UNKILLABLE”前置条件，避免多段伤害（如堡垒榴弹）导致效果在死亡后才误触发。
+- 「有我有你（Buff 12）」在解除附身时会同步附身者与被附身者的 `controlJumpIndex`（仅在目标索引更高时同步），避免三合一地图跨图传送后出现索引回退导致的传送点失效。
 - 清理逻辑统一走 `clearPlayerEvent()`，减少状态泄漏。
 - 数值更新统一走 `updatePlayerStats()`，避免重复写 setXxx。
 

--- a/src/events/effects/buffEffects.opy
+++ b/src/events/effects/buffEffects.opy
@@ -320,6 +320,18 @@ rule "[VishkarEvent]: 有我有你 (Initiator - Control Logic)":
         eventPlayer.getHero() == heroList[eventPlayer.heroNumber]
     ]):
         progressHero()
+
+    # 三合一地图控制点同步：若被附身目标在附身期间完成了传送点推进，
+    # 解除附身后将附身者的 controlJumpIndex 同步到不落后于目标，
+    # 避免“目标已过图但附身者仍停留上一图索引”导致后续传送失效。
+    if all([
+        controlRespawnPosition != null,
+        eventPlayer.possess != null,
+        eventPlayer.possess[0] != null,
+        entityExists(eventPlayer.possess[0]),
+        eventPlayer.possess[0].controlJumpIndex > eventPlayer.controlJumpIndex
+    ]):
+        eventPlayer.controlJumpIndex = eventPlayer.possess[0].controlJumpIndex
     
     # 寻找安全落脚点
     # 使用标准重生室判定：若附身者已在重生室，则不再执行落脚传送


### PR DESCRIPTION
### Motivation
- 修复在三合一大地图中当被附身目标通过传送点后阵亡导致附身者解除附身但其 `controlJumpIndex` 仍为旧值，从而不能通过当前地图传送点的异常行为。

### Description
- 在 `src/events/effects/buffEffects.opy` 的“有我有你 (Initiator - Control Logic)”清理阶段新增向前同步逻辑：当 `controlRespawnPosition != null` 且被附身目标存在且其 `controlJumpIndex` 更大时，将附身者的 `controlJumpIndex` 更新为目标值以避免回退。
- 仅在目标索引更高的情况下执行同步，保证不会回退附身者的进度。
- 更新文档 `docs/modules/03-events-system.md`，说明 Buff 12 在解除附身时会做 `controlJumpIndex` 同步。

### Testing
- 运行 `./tools/check_locale_keys.sh`，检查通过且未发现阻塞性问题。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a18ffe0d98832a8ca1563c28ca9520)