### PR TITLE
feat: Trinity (Mech 20) damage reduction and speed scaling

### DIFF
--- a/src/constants/event_constants.opy
+++ b/src/constants/event_constants.opy
@@ -1012,10 +1012,10 @@
 #!define EVT_MECH_20_DMG_REDUCE_CAP 85
 
 # 减伤成长：reduce = min(cap, MaxHP / divisor)
-#!define EVT_MECH_20_DMG_REDUCE_DIVISOR 40
+#!define EVT_MECH_20_DMG_REDUCE_DIVISOR 25
 
 # 移速系数：speed = (-mod_dmg_taken) * factor
-#!define EVT_MECH_20_SPEED_FACTOR 2
+#!define EVT_MECH_20_SPEED_FACTOR 2.5
 
 # 心之钢每跳增加量
 #!define EVT_MECH_20_HEART_STEEL_PER_TICK 0.25

--- a/src/locales/en-US.opy
+++ b/src/locales/en-US.opy
@@ -235,7 +235,7 @@
 #!define STR_EVT_MECH_19_TITLE "Valkyrie's Descent"
 #!define STR_EVT_MECH_19_DESC "Become BOSS: 500% HP.\nNo healing received. Heal via Ultimate."
 #!define STR_EVT_MECH_20_TITLE "Trinity"
-#!define STR_EVT_MECH_20_DESC "100HP->2.5% DR, 1% DR->2% Speed, 100% Speed/s->1 Heartsteel."
+#!define STR_EVT_MECH_20_DESC "100HP->4% DR, 1% DR->2.5% Speed, 100% Speed/s->1 Heartsteel."
 
 # Settings Categories
 #!define STR_CAT_RANDOM_PACK "Random Events Pack"

--- a/src/locales/zh-CN.opy
+++ b/src/locales/zh-CN.opy
@@ -241,7 +241,7 @@
 #!define STR_EVT_MECH_19_TITLE "瓦尔基里降临"
 #!define STR_EVT_MECH_19_DESC "生命值提高1000%，获得禁疗\n受到伤害获得大招充能\n大招持续期间最多回复85%生命值"
 #!define STR_EVT_MECH_20_TITLE "三位一体"
-#!define STR_EVT_MECH_20_DESC "100HP→2.5%减伤，1%减伤→2%移速\n每5秒获得1层心之钢"
+#!define STR_EVT_MECH_20_DESC "100HP→4%减伤，1%减伤→2.5%移速\n每5秒获得1层心之钢"
 
 
 # 设置菜单分类 (Pack)


### PR DESCRIPTION
### Motivation

- Trinity (Mech 20) event was underpowered relative to its 0.2 rare weight, so its damage-reduction and movement-speed conversion were increased while preserving Heartsteel stacking behavior.

### Description

- Increase `EVT_MECH_20_DMG_REDUCE_DIVISOR` from `40` to `25` in `src/constants/event_constants.opy` to strengthen DR scaling. 
- Increase `EVT_MECH_20_SPEED_FACTOR` from `2` to `2.5` in `src/constants/event_constants.opy` to raise speed gained per DR. 
- Update human-facing text in `src/locales/zh-CN.opy` and `src/locales/en-US.opy` so descriptions match the new numbers. 
- Change scope limited to event constants and locale strings; no entry/include or gameplay-flow files were modified.

### Testing

- Verified the updated constants and locale strings with `rg` lookups which found the new values. 
- Ran `tools/check_locale_keys.sh` and it passed with no blocking issues. 
- Performed a basic HTTP probe (`curl -I`) for external reference availability during validation (request completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1a838248c832a9ce937ce9bd75d52)