### PR TITLE
fix: prevent 胜利意志 from activating after player death

### DIFF
--- a/src/events/effects/buffEffects.opy
+++ b/src/events/effects/buffEffects.opy
@@ -572,6 +572,7 @@ rule "[VishkarEvent]: 坚定":
 rule "[VishkarEvent]: 胜利意志":
     @Event eachPlayer
     @Team 1
+    @Condition eventPlayer.isAlive() == true
     @Condition all([dlcVishkarEvent, eventPlayer.hasSpawned(), eventPlayer.eventType == 0, eventPlayer.eventId == BuffEventId.WILL_TO_WIN, eventPlayer.getHealth() <= eventPlayer.getMaxHealth() * EVT_19_TRIGGER_HP_PERCENT]) == true
     
     waitUntil(eventPlayer.isAlive(), MAX_TIME)


### PR DESCRIPTION
### Motivation
- Fix a bug where the `胜利意志` (Will to Win) event could satisfy its low-HP trigger while the player was dead and then activate after respawn, causing incorrect invincibility and healing behavior.

### Description
- Added an explicit alive-state condition (`@Condition eventPlayer.isAlive() == true`) to the `[VishkarEvent]: 胜利意志` rule in `src/events/effects/buffEffects.opy` to ensure the rule only evaluates for living players; no other files or entry points were modified.

### Testing
- Ran `tools/check_locale_keys.sh` which completed successfully with only existing non-blocking unused-key warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1cb8d1e98832ab0def25d6adb0ddb)