### PR TITLE
Add '花终落' to blacklist entry

### DIFF
--- a/src/blacklist/init.opy
+++ b/src/blacklist/init.opy
@@ -4,4 +4,4 @@ globalvar blackList
 
 rule "Setup Blacklist":
     blackList = []
-    blackList.append("船长-六十块就这样没了-Pakho-希望小晨永远开心-田哈哈".split("-"))
+    blackList.append("船长-六十块就这样没了-Pakho-希望小晨永远开心-田哈哈-花终落".split("-"))


### PR DESCRIPTION
### Motivation
- Ensure the startup blacklist includes the missing token `花终落` so the in-memory `blackList` contains the complete set of names.

### Description
- Updated `src/blacklist/init.opy` by extending the string passed to `blackList.append(...)` so the split result includes `花终落`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a2f3aa10fc832aadd6543d7ec4ad0e)