### PR TITLE
fix: preserve Trinity (Mech 20) stacking across death

### DIFF
--- a/src/events/effects/mechEffects.opy
+++ b/src/events/effects/mechEffects.opy
@@ -470,14 +470,15 @@ rule "[VishkarEvent]: 瓦尔基里降临 (大招持续回血)":
 rule "[VishkarEvent]: 三位一体 (SSR)":
     @Event eachPlayer
     @Team 1
-    @Condition all([dlcVishkarEvent, eventPlayer.hasSpawned(), eventPlayer.isAlive(), eventPlayer.eventType == 2, eventPlayer.eventId == MechEventId.TRINITY_SSR]) == true
+    @Condition all([dlcVishkarEvent, eventPlayer.hasSpawned(), eventPlayer.eventType == 2, eventPlayer.eventId == MechEventId.TRINITY_SSR]) == true
     
-    eventPlayer.mod_dmg_taken = negToPos(min(EVT_MECH_20_DMG_REDUCE_CAP, eventPlayer.getMaxHealth() / EVT_MECH_20_DMG_REDUCE_DIVISOR))
-    eventPlayer.mod_speed_event = eventPlayer.mod_dmg_taken * -EVT_MECH_20_SPEED_FACTOR
-    updatePlayerStats()
-    eventPlayer.heart_steel += EVT_MECH_20_HEART_STEEL_PER_TICK
-    setPlayerHP()
-    eventPlayer.hudText = "伤害减免：{0}% / 移速加成：{1}% / 心之钢：{2}层".format(negToPos(eventPlayer.mod_dmg_taken), eventPlayer.mod_speed_event, round(eventPlayer.heart_steel))
+    if eventPlayer.isAlive():
+        eventPlayer.mod_dmg_taken = negToPos(min(EVT_MECH_20_DMG_REDUCE_CAP, eventPlayer.getMaxHealth() / EVT_MECH_20_DMG_REDUCE_DIVISOR))
+        eventPlayer.mod_speed_event = eventPlayer.mod_dmg_taken * -EVT_MECH_20_SPEED_FACTOR
+        updatePlayerStats()
+        eventPlayer.heart_steel += EVT_MECH_20_HEART_STEEL_PER_TICK
+        setPlayerHP()
+        eventPlayer.hudText = "伤害减免：{0}% / 移速加成：{1}% / 心之钢：{2}层".format(negToPos(eventPlayer.mod_dmg_taken), eventPlayer.mod_speed_event, round(eventPlayer.heart_steel))
     wait(EVT_MECH_20_INTERVAL)
     if ruleCondition:
         loop()


### PR DESCRIPTION
### Motivation
- Fix a bug where the Mech 20 (TRINITY_SSR / 三位一体) rule would stop running when a player briefly died, causing `mod_dmg_taken` / `mod_speed_event` to be reset and preventing stacking after respawn.

### Description
- Removed `eventPlayer.isAlive()` from the rule condition so the per-player rule remains active across death/respawn cycles.
- Gated the buff/stack update logic with `if eventPlayer.isAlive():` inside the rule so stats are only updated while the player is alive but the loop doesn't exit when they die.
- Kept the existing cleanup that zeroes modifiers only at rule termination so the periodic stacking behavior now persists correctly across deaths.

### Testing
- Ran `pnpm run build` which compiles both `main` and `dev` entries and completed successfully (warnings from unrelated checks remain but do not affect this fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad42b1c228832a88810e93be6b9f04)