### PR TITLE
feat: Lower “我要验牌” Heart Steel cost to 2

### DIFF
--- a/src/constants/event_constants.opy
+++ b/src/constants/event_constants.opy
@@ -861,7 +861,7 @@
 #!define EVT_MECH_10_DURATION 15
 # Weight（权重）
 #!define EVT_MECH_10_WEIGHT 1.2
-#!define EVT_MECH_10_HEART_STEEL_COST 6
+#!define EVT_MECH_10_HEART_STEEL_COST 2
 #!define EVT_MECH_10_FORCE_ROLL 20
 
 # --- ID 11 (Mech/Special): 作弊：回溯 ---


### PR DESCRIPTION
### Motivation
- Reduce the Heart Steel consumption for the Mech event “作弊：我要验牌” to match the balance request (lower cost from 6 stacks to 2 stacks).

### Description
- Change `EVT_MECH_10_HEART_STEEL_COST` from `6` to `2` in `src/constants/event_constants.opy` as a minimal, scope-limited balance tweak.

### Testing
- Ran `pnpm run build` (both `build:main` and `build:dev`) which completed successfully; OverPy produced warnings but no build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b172febb1c832aa7b74136632d1be8)