### PR TITLE
feat: Nerf 'Draw Fire' armor from 500 to 350

### DIFF
--- a/src/constants/event_constants.opy
+++ b/src/constants/event_constants.opy
@@ -393,7 +393,7 @@
 # Weight（权重）
 #!define EVT_BUFF_33_WEIGHT 1.4
 #!define EVT_33_DMG_TAKEN -50
-#!define EVT_33_ARMOR_AMOUNT 500
+#!define EVT_33_ARMOR_AMOUNT 350
 #!define EVT_33_TARGET_WEIGHT 999
 
 # --- ID 34: 坚韧 ---


### PR DESCRIPTION
### Motivation
- Reduce the potency of the buff event “向我开炮” (Draw Fire) by lowering its recoverable armor pool to make the effect less powerful.

### Description
- Change `EVT_33_ARMOR_AMOUNT` from `500` to `350` in `src/constants/event_constants.opy`, which updates the runtime effect and the formatted event description.

### Testing
- Ran `pnpm run build:main` and `pnpm run build:dev`, and both completed successfully with only existing non-blocking warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b173b7c3dc832a99e4149176323c1d)